### PR TITLE
Metadata key-value store + flight log hash check

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -27,3 +27,19 @@ Events are created by the app with UTC time zone: the app will use the aircraft 
 ## Google Sheet setup
 
 > TODO log book sheet creation and formulas
+
+### Custom sheet code
+
+This is the function used to calculate the flight log checksum:
+
+```javascript
+// input must be a scalar value
+function HASH (input) {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash << 5) - hash + input.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+```

--- a/lib/generated/intl/app_localizations.dart
+++ b/lib/generated/intl/app_localizations.dart
@@ -608,6 +608,12 @@ abstract class AppLocalizations {
   /// **'This is a test flight, you cannot change the pilot.'**
   String get flightLogModal_error_alteringTestFlight;
 
+  /// No description provided for @flightLogModal_error_dataChanged.
+  ///
+  /// In en, this message translates to:
+  /// **'Someone else changed the flight log. Go back, refresh the log book and try again.'**
+  String get flightLogModal_error_dataChanged;
+
   /// No description provided for @flightLogModal_dialog_changePilot_title.
   ///
   /// In en, this message translates to:

--- a/lib/generated/intl/app_localizations_en.dart
+++ b/lib/generated/intl/app_localizations_en.dart
@@ -297,6 +297,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'This is a test flight, you cannot change the pilot.';
 
   @override
+  String get flightLogModal_error_dataChanged =>
+      'Someone else changed the flight log. Go back, refresh the log book and try again.';
+
+  @override
   String get flightLogModal_dialog_changePilot_title => 'Change pilot?';
 
   @override

--- a/lib/generated/intl/app_localizations_it.dart
+++ b/lib/generated/intl/app_localizations_it.dart
@@ -298,6 +298,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Il volo è una prova tecnica, non puoi cambiare pilota.';
 
   @override
+  String get flightLogModal_error_dataChanged =>
+      'Qualcun altro ha cambiato il log book. Torna indietro, ricarica il log book e riprova.';
+
+  @override
   String get flightLogModal_dialog_changePilot_title => 'Cambiare pilota?';
 
   @override

--- a/lib/helpers/config.dart
+++ b/lib/helpers/config.dart
@@ -47,6 +47,10 @@ class AppConfig extends ChangeNotifier {
         return _currentAircraft!.backendInfo['activities_spreadsheet_id'] !=
                 null &&
             _currentAircraft!.backendInfo['activities_sheet_name'] != null;
+      case 'metadata':
+        return _currentAircraft!.backendInfo['metadata_spreadsheet_id'] !=
+                null &&
+            _currentAircraft!.backendInfo['metadata_sheet_name'] != null;
       default:
         throw Exception('Unknown feature: $feature');
     }
@@ -82,6 +86,15 @@ class AppConfig extends ChangeNotifier {
       'spreadsheet_id':
           _currentAircraft!.backendInfo['activities_spreadsheet_id'],
       'sheet_name': _currentAircraft!.backendInfo['activities_sheet_name'],
+    };
+  }
+
+  // TODO new entries: define backward-compatibility strategy
+  Map<String, String> get metadataBackendInfo {
+    return {
+      'spreadsheet_id':
+          _currentAircraft!.backendInfo['metadata_spreadsheet_id'],
+      'sheet_name': _currentAircraft!.backendInfo['metadata_sheet_name'],
     };
   }
 

--- a/lib/helpers/config.dart
+++ b/lib/helpers/config.dart
@@ -89,7 +89,6 @@ class AppConfig extends ChangeNotifier {
     };
   }
 
-  // TODO new entries: define backward-compatibility strategy
   Map<String, String> get metadataBackendInfo {
     return {
       'spreadsheet_id':

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -142,6 +142,7 @@
   "flightLogModal_error_invalid_fuelCost": "Invalid fuel cost.",
   "flightLogModal_error_notOwnFlight_edit": "Flight is not yours, you cannot modify it.",
   "flightLogModal_error_alteringTestFlight": "This is a test flight, you cannot change the pilot.",
+  "flightLogModal_error_dataChanged": "Someone else changed the flight log. Go back, refresh the log book and try again.",
   "flightLogModal_dialog_changePilot_title": "Change pilot?",
   "flightLogModal_dialog_changePilot_message": "You are changing the pilot of a registered flight.",
   "flightLogModal_dialog_changePilotNoPilot_message": "You are turning this flight into a test flight.",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -93,6 +93,7 @@
   "flightLogModal_error_invalid_fuelCost": "Costo totale benzina non valido.",
   "flightLogModal_error_notOwnFlight_edit": "Il volo non è tuo, non puoi modificarlo.",
   "flightLogModal_error_alteringTestFlight": "Il volo è una prova tecnica, non puoi cambiare pilota.",
+  "flightLogModal_error_dataChanged": "Qualcun altro ha cambiato il log book. Torna indietro, ricarica il log book e riprova.",
   "flightLogModal_dialog_changePilot_title": "Cambiare pilota?",
   "flightLogModal_dialog_changePilot_message": "Stai cambiando il pilota di un volo registrato.",
   "flightLogModal_dialog_changePilotNoPilot_message": "Stai trasformando il volo in una prova tecnica.",

--- a/lib/screens/flight_log/flight_log_modal.dart
+++ b/lib/screens/flight_log/flight_log_modal.dart
@@ -650,6 +650,8 @@ class _FlightLogModalState extends State<FlightLogModal> {
       // TODO specialize exceptions (e.g. network errors, others...)
       if (error is TimeoutException) {
         message = AppLocalizations.of(context)!.error_generic_network_timeout;
+      } else if (error is DataChangedException) {
+        message = AppLocalizations.of(context)!.flightLogModal_error_dataChanged;
       } else {
         message = getExceptionMessage(error);
       }

--- a/lib/screens/main/main_screen.dart
+++ b/lib/screens/main/main_screen.dart
@@ -10,6 +10,7 @@ import '../../helpers/utils.dart';
 import '../../services/activities_services.dart';
 import '../../services/book_flight_services.dart';
 import '../../services/flight_log_services.dart';
+import '../../services/metadata_services.dart';
 import '../about/about_screen.dart';
 import '../activities/activities_screen.dart';
 import '../book_flight/book_flight_screen.dart';
@@ -22,13 +23,15 @@ class MainNavigation extends StatefulWidget {
   final BookFlightCalendarService? bookFlightCalendarService;
   final FlightLogBookService? flightLogBookService;
   final ActivitiesService? activitiesService;
+  final MetadataService? metadataService;
 
   // TODO other services one day...
 
   const MainNavigation(this.appConfig, {super.key})
       : bookFlightCalendarService = null,
         flightLogBookService = null,
-        activitiesService = null;
+        activitiesService = null,
+        metadataService = null;
 
   /// Mainly for integration testing.
   @visibleForTesting
@@ -38,6 +41,7 @@ class MainNavigation extends StatefulWidget {
     this.bookFlightCalendarService,
     this.flightLogBookService,
     this.activitiesService,
+    this.metadataService,
   });
 
   @override
@@ -78,7 +82,10 @@ class _MainNavigationState extends State<MainNavigation> {
     _flightLogBookService = widget.flightLogBookService ??
         (widget.appConfig.hasFeature('flight_log')
             ? FlightLogBookService(
-                account!, widget.appConfig.flightlogBackendInfo)
+                account!, widget.metadataService ??
+            (widget.appConfig.hasFeature('metadata')
+                ? MetadataService(account, widget.appConfig.metadataBackendInfo)
+                : null), widget.appConfig.flightlogBackendInfo)
             : null);
     _activitiesService = widget.activitiesService ??
         (widget.appConfig.hasFeature('activities')

--- a/lib/screens/main/main_screen.dart
+++ b/lib/screens/main/main_screen.dart
@@ -69,28 +69,29 @@ class _MainNavigationState extends State<MainNavigation> {
   }
 
   void _rebuildServices() {
-    final account = (widget.bookFlightCalendarService == null &&
-            widget.flightLogBookService == null)
-        ? GoogleServiceAccountService(
-            json: widget.appConfig.googleServiceAccountJson)
-        : null;
+    // FIXME if the services are already built (or provided) this variable is not used
+    final account = GoogleServiceAccountService(
+        json: widget.appConfig.googleServiceAccountJson);
+
     _bookFlightCalendarService = widget.bookFlightCalendarService ??
         (widget.appConfig.hasFeature('book_flight')
             ? BookFlightCalendarService(
-                account!, widget.appConfig.googleCalendarId)
+                account, widget.appConfig.googleCalendarId)
             : null);
     _flightLogBookService = widget.flightLogBookService ??
         (widget.appConfig.hasFeature('flight_log')
             ? FlightLogBookService(
-                account!, widget.metadataService ??
-            (widget.appConfig.hasFeature('metadata')
-                ? MetadataService(account, widget.appConfig.metadataBackendInfo)
-                : null), widget.appConfig.flightlogBackendInfo)
+                account,
+                widget.metadataService ??
+                    (widget.appConfig.hasFeature('metadata')
+                        ? MetadataService(
+                            account, widget.appConfig.metadataBackendInfo)
+                        : null),
+                widget.appConfig.flightlogBackendInfo)
             : null);
     _activitiesService = widget.activitiesService ??
         (widget.appConfig.hasFeature('activities')
-            ? ActivitiesService(
-                account!, widget.appConfig.activitiesBackendInfo)
+            ? ActivitiesService(account, widget.appConfig.activitiesBackendInfo)
             : null);
   }
 

--- a/lib/services/flight_log_services.dart
+++ b/lib/services/flight_log_services.dart
@@ -81,19 +81,16 @@ class FlightLogBookService {
   }
 
   /// Completes correctly if hash has not changed, throws exception otherwise.
-  Future<void> _ensureUnchangedHash() {
+  Future<void> _ensureUnchangedHash() async {
     if (_metadataService != null) {
-      return _metadataService!.reload().then((store) {
-        final newHash = store[_kLogHashMetadataKey];
-        _log.finest('Old hash: $_dataHash, new hash: $newHash');
-        if (newHash == null) {
-          throw const FormatException('No data found on sheet.');
-        } else if (newHash != _dataHash) {
-          throw const DataChangedException();
-        }
-      });
-    } else {
-      return Future.value();
+      final store = await _metadataService!.reload();
+      final newHash = store[_kLogHashMetadataKey];
+      _log.finest('Old hash: $_dataHash, new hash: $newHash');
+      if (newHash == null) {
+        throw const FormatException('No data found on sheet.');
+      } else if (newHash != _dataHash) {
+        throw const DataChangedException();
+      }
     }
   }
 

--- a/lib/services/flight_log_services.dart
+++ b/lib/services/flight_log_services.dart
@@ -95,6 +95,7 @@ class FlightLogBookService {
   }
 
   /// Data range generator. +2 because the index is 0-based and to skip the header row.
+  // TODO refactor this +2/-1/+1 stuff, it's too confusing
   String _sheetDataRange(int first, int last) => 'A${first + 2}:J${last + 2}';
 
   /// Convert item ID to sheet row number. +1 is for skipping the header row.

--- a/lib/services/flight_log_services.dart
+++ b/lib/services/flight_log_services.dart
@@ -149,6 +149,7 @@ class FlightLogBookService {
               .then((value) {
             // update our local copy of the flight log hash
             final store = value[1] as Map<String, String>;
+            // TODO the hash should be checked between pages, causing interruption of infinite scroll in case of change
             _dataHash = store[_kLogHashMetadataKey];
             return value[0] as ValueRange;
           });

--- a/lib/services/flight_log_services.dart
+++ b/lib/services/flight_log_services.dart
@@ -64,6 +64,11 @@ class FlightLogBookService {
   @visibleForTesting
   int get lastId => _lastId;
 
+  @visibleForTesting
+  set dataHash(String dataHash) {
+    _dataHash = dataHash;
+  }
+
   Future<GoogleSheetsService> _ensureService() {
     if (_client != null) {
       return Future.value(_client);

--- a/lib/services/flight_log_services.dart
+++ b/lib/services/flight_log_services.dart
@@ -116,7 +116,8 @@ class FlightLogBookService {
             throw const FormatException('No data found on sheet.');
           }
           _lastId = int.parse(value);
-          _dataHash = value;
+          // hash will be retrieved during the first fetch
+          _dataHash = null;
           _log.finest('lastId is $_lastId');
         });
       } else {

--- a/lib/services/metadata_services.dart
+++ b/lib/services/metadata_services.dart
@@ -48,7 +48,7 @@ class MetadataService {
         : reload().then((value) => _store!);
   }
 
-  Future<void> reload() {
+  Future<Map<String, String>> reload() {
     return _ensureService().then((client) => client
             .getRows(_spreadsheetId, _sheetName, _kSheetKeyValueRange)
             .then((value) {
@@ -62,6 +62,7 @@ class MetadataService {
 
           _store = store;
           _log.info(store);
+          return store;
         }));
   }
 

--- a/lib/services/metadata_services.dart
+++ b/lib/services/metadata_services.dart
@@ -42,10 +42,12 @@ class MetadataService {
     }
   }
 
-  Future<Map<String, String>> _ensureCache() {
-    return _store != null
-        ? Future.value(_store!)
-        : reload().then((value) => _store!);
+  Future<Map<String, String>> _ensureCache() async {
+    if (_store != null) {
+      return _store!;
+    } else {
+      return await reload();
+    }
   }
 
   Future<Map<String, String>> reload() {

--- a/lib/services/metadata_services.dart
+++ b/lib/services/metadata_services.dart
@@ -1,0 +1,73 @@
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+
+import '../helpers/googleapis.dart';
+
+/// Data range for the key-value store.
+const _kSheetKeyValueRange = 'A2:B';
+
+final Logger _log = Logger((MetadataService).toString());
+
+class MetadataService {
+  late final GoogleServiceAccountService _accountService;
+  late final String _spreadsheetId;
+  late final String _sheetName;
+  GoogleSheetsService? _client;
+
+  /// Cached key-value store
+  Map<String, String>? _store;
+
+  MetadataService(GoogleServiceAccountService accountService,
+      Map<String, String> properties) {
+    _accountService = accountService;
+    _spreadsheetId = properties['spreadsheet_id']!;
+    _sheetName = properties['sheet_name']!;
+  }
+
+  @visibleForTesting
+  set client(GoogleSheetsService client) {
+    _client = client;
+  }
+
+  Future<GoogleSheetsService> _ensureService() {
+    if (_client != null) {
+      return Future.value(_client);
+    } else {
+      return _accountService.getAuthenticatedClient().then((client) {
+        _client = GoogleSheetsService(client);
+        return _client!;
+      });
+    }
+  }
+
+  Future<Map<String, String>> _ensureCache() {
+    return _store != null
+        ? Future.value(_store!)
+        : reload().then((value) => _store!);
+  }
+
+  Future<void> reload() {
+    return _ensureService().then((client) => client
+            .getRows(_spreadsheetId, _sheetName, _kSheetKeyValueRange)
+            .then((value) {
+          if (value.values == null) {
+            throw const FormatException('No data found on sheet.');
+          }
+          Map<String, String> store = HashMap();
+          for (var item in value.values!) {
+            store[item[0] as String] = item[1].toString();
+          }
+
+          _store = store;
+          _log.info(store);
+        }));
+  }
+
+  Future<String?> get(String key) {
+    return _ensureCache().then((value) {
+      return _store![key]?.toString();
+    });
+  }
+}

--- a/lib/services/metadata_services.dart
+++ b/lib/services/metadata_services.dart
@@ -57,7 +57,11 @@ class MetadataService {
           }
           Map<String, String> store = HashMap();
           for (var item in value.values!) {
-            store[item[0] as String] = item[1].toString();
+            if (item.length >= 2) {
+              store[item[0] as String] = item[1].toString();
+            } else {
+              _log.warning('Skipping malformed row in metadata: $item');
+            }
           }
 
           _store = store;
@@ -68,7 +72,7 @@ class MetadataService {
 
   Future<String?> get(String key) {
     return _ensureCache().then((value) {
-      return _store![key]?.toString();
+      return _store![key];
     });
   }
 }

--- a/lib/services/metadata_services.dart
+++ b/lib/services/metadata_services.dart
@@ -50,26 +50,26 @@ class MetadataService {
     }
   }
 
-  Future<Map<String, String>> reload() {
-    return _ensureService().then((client) => client
-            .getRows(_spreadsheetId, _sheetName, _kSheetKeyValueRange)
-            .then((value) {
-          if (value.values == null) {
-            throw const FormatException('No data found on sheet.');
-          }
-          Map<String, String> store = HashMap();
-          for (var item in value.values!) {
-            if (item.length >= 2) {
-              store[item[0].toString()] = item[1].toString();
-            } else {
-              _log.warning('Skipping malformed row in metadata: $item');
-            }
-          }
+  Future<Map<String, String>> reload() async {
+    final client = await _ensureService();
+    final value =
+        await client.getRows(_spreadsheetId, _sheetName, _kSheetKeyValueRange);
+    if (value.values == null) {
+      throw const FormatException('No data found on sheet.');
+    }
 
-          _store = store;
-          _log.info(store);
-          return store;
-        }));
+    Map<String, String> store = HashMap();
+    for (var item in value.values!) {
+      if (item.length >= 2) {
+        store[item[0].toString()] = item[1].toString();
+      } else {
+        _log.warning('Skipping malformed row in metadata: $item');
+      }
+    }
+
+    _store = store;
+    _log.info(store);
+    return store;
   }
 
   Future<String?> get(String key) async {

--- a/lib/services/metadata_services.dart
+++ b/lib/services/metadata_services.dart
@@ -72,9 +72,8 @@ class MetadataService {
         }));
   }
 
-  Future<String?> get(String key) {
-    return _ensureCache().then((value) {
-      return _store![key];
-    });
+  Future<String?> get(String key) async {
+    final store = await _ensureCache();
+    return store[key];
   }
 }

--- a/lib/services/metadata_services.dart
+++ b/lib/services/metadata_services.dart
@@ -60,7 +60,7 @@ class MetadataService {
           Map<String, String> store = HashMap();
           for (var item in value.values!) {
             if (item.length >= 2) {
-              store[item[0] as String] = item[1].toString();
+              store[item[0].toString()] = item[1].toString();
             } else {
               _log.warning('Skipping malformed row in metadata: $item');
             }

--- a/screenshots/fake_data.dart
+++ b/screenshots/fake_data.dart
@@ -190,6 +190,7 @@ class MainNavigationApp extends StatelessWidget {
               bookFlightCalendarService: FakeCalendarService(generateFakeEvents(appConfig.pilotNames)),
               flightLogBookService: FakeLogBookService(generateFakeLogBookItems(appConfig.pilotNames)),
               activitiesService: FakeActivitiesService(generateFakeActivities(appConfig.pilotNames)),
+              // TODO metadataService: ...
             ),
             'pilot-select': (context) => const PilotSelectScreen(),
           },

--- a/test/services/flight_log_services_test.dart
+++ b/test/services/flight_log_services_test.dart
@@ -1,6 +1,7 @@
 import 'package:airborne/helpers/googleapis.dart';
 import 'package:airborne/models/flight_log_models.dart';
 import 'package:airborne/services/flight_log_services.dart';
+import 'package:airborne/services/metadata_services.dart';
 import 'package:googleapis/sheets/v4.dart' as gapi_sheets;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/intl.dart';
@@ -9,19 +10,24 @@ import 'package:mockito/mockito.dart';
 
 import 'flight_log_services_test.mocks.dart';
 
-@GenerateMocks([GoogleSheetsService, GoogleServiceAccountService])
+@GenerateMocks(
+    [GoogleSheetsService, GoogleServiceAccountService, MetadataService])
 void main() {
   late MockGoogleSheetsService mockSheetsService;
+  late MockMetadataService mockMetadataService;
   late FlightLogBookService testService;
   final datetimeFormatter = DateFormat('yyyy-MM-dd HH:mm:SS');
 
   setUp(() {
     mockSheetsService = MockGoogleSheetsService();
-    testService = FlightLogBookService(MockGoogleServiceAccountService(), {
+    mockMetadataService = MockMetadataService();
+    testService = FlightLogBookService(
+        MockGoogleServiceAccountService(), mockMetadataService, {
       'spreadsheet_id': 'TEST',
       'sheet_name': 'SHEET',
     });
     testService.client = mockSheetsService;
+    testService.dataHash = '12345678';
   });
   tearDown(() {});
 
@@ -55,6 +61,8 @@ void main() {
     );
     when(mockSheetsService.getRows('TEST', 'SHEET', 'A2:J3'))
         .thenAnswer((_) => Future.value(fakeRows));
+    when(mockMetadataService.reload()).thenAnswer((_) => Future.value(<String, String>{}));
+    when(mockMetadataService.get(any)).thenAnswer((_) => Future.value(null));
 
     final dateOnly =
         DateTime.utc(timestamp.year, timestamp.month, timestamp.day);
@@ -82,6 +90,12 @@ void main() {
     );
     when(mockSheetsService.appendRows('TEST', 'SHEET', 'A2:J2', any))
         .thenAnswer((_) => Future.value(fakeAppended));
+    when(mockMetadataService.reload()).thenAnswer((_) => Future.value(<String, String>{
+      'flight_log.count': '0',
+      'flight_log.hash': '12345678'
+    }));
+    when(mockMetadataService.get('flight_log.count')).thenAnswer((_) => Future.value('0'));
+    when(mockMetadataService.get('flight_log.hash')).thenAnswer((_) => Future.value('12345678'));
 
     final dateOnly =
         DateTime.utc(timestamp.year, timestamp.month, timestamp.day);
@@ -101,6 +115,12 @@ void main() {
     );
     when(mockSheetsService.updateRows('TEST', 'SHEET', 'A2:J2', any))
         .thenAnswer((_) => Future.value(fakeAppended));
+    when(mockMetadataService.reload()).thenAnswer((_) => Future.value(<String, String>{
+      'flight_log.count': '1',
+      'flight_log.hash': '12345678'
+    }));
+    when(mockMetadataService.get('flight_log.count')).thenAnswer((_) => Future.value('1'));
+    when(mockMetadataService.get('flight_log.hash')).thenAnswer((_) => Future.value('12345678'));
 
     final dateOnly =
         DateTime.utc(timestamp.year, timestamp.month, timestamp.day);
@@ -125,6 +145,12 @@ void main() {
         );
     when(mockSheetsService.deleteRows('TEST', 'SHEET', 2, 2))
         .thenAnswer((_) => Future.value(fakeAppended));
+    when(mockMetadataService.reload()).thenAnswer((_) => Future.value(<String, String>{
+      'flight_log.count': '1',
+      'flight_log.hash': '12345678'
+    }));
+    when(mockMetadataService.get('flight_log.count')).thenAnswer((_) => Future.value('1'));
+    when(mockMetadataService.get('flight_log.hash')).thenAnswer((_) => Future.value('12345678'));
 
     final dateOnly =
         DateTime.utc(timestamp.year, timestamp.month, timestamp.day);


### PR DESCRIPTION
This PR adds a service for a read-only key-value store, backed by a sheet in a Google Sheets document. The sheet is very simple:

|Key|Value|
|----|----|
|`flight_log.count`|12|
|`flight_log.hash`|3324987234|

This will also move the flight log row count from cell A0 of the flight log itself, to this new key-value store (key `flight_log.count`). This modification is backward-compatible: the app will fall back to the old method if the key-value sheet or the value itself are not available.

To prevent accidental conflicts from concurrent modifications to the flight log, a hash (more of a simple checksum actually) is computed from the whole flight log and saved in the key-value store under the key `flight_log.hash`. The hash is used to quickly check if the flight log had modifications while the user is adding/updating/deleting a flight. If the hash changed, the app will now prevent the action, forcing the user to go back to the flight log list, refresh it and begin from scratch.

Closes #75.